### PR TITLE
feat(prepare-c-flag): add noAnchestors option to config

### DIFF
--- a/packages/sfp-cli/resources/schemas/pooldefinition.schema.json
+++ b/packages/sfp-cli/resources/schemas/pooldefinition.schema.json
@@ -119,6 +119,12 @@
             "type": "boolean",
             "default":false
         },
+        "noAnchestors": {
+            "title": "Disable second-generation managed package (2GP) ancestors in the scratch org.",
+            "description": "Don't include second-generation managed package (2GP) ancestors in the scratch org when set to true",
+            "type": "boolean",
+            "default":false
+        },
         "fetchArtifacts": {
             "title": "Fetch Artifacts using below mechanism",
             "description": "Fetch artifacts from artifact registry using below mechanism",

--- a/packages/sfp-cli/src/core/scratchorg/ScratchOrgOperator.ts
+++ b/packages/sfp-cli/src/core/scratchorg/ScratchOrgOperator.ts
@@ -7,6 +7,7 @@ import { ScratchOrgRequest } from '@salesforce/core';
 import { COLOR_KEY_MESSAGE } from '@flxblio/sfp-logger';
 import getFormattedTime from '../utils/GetFormattedTime';
 import SFPStatsSender from '../stats/SFPStatsSender';
+import { PoolConfig } from './pool/PoolConfig';
 const retry = require('async-retry');
 
 export default class ScratchOrgOperator {
@@ -16,7 +17,8 @@ export default class ScratchOrgOperator {
         alias: string,
         config_file_path: string,
         expiry: number,
-        waitTime: number = 6
+        waitTime: number = 6,
+        poolConfig: Partial<PoolConfig>
     ): Promise<ScratchOrg> {
         SFPLogger.log('Parameters: ' + alias + ' ' + config_file_path + ' ' + expiry + ' ', LoggerLevel.TRACE);
 
@@ -26,7 +28,8 @@ export default class ScratchOrgOperator {
             alias,
             config_file_path,
             Duration.days(expiry),
-            Duration.minutes(waitTime)
+            Duration.minutes(waitTime),
+            poolConfig
         );
         SFPLogger.log(JSON.stringify(scatchOrgResult), LoggerLevel.TRACE);
 
@@ -81,11 +84,11 @@ export default class ScratchOrgOperator {
         );
     }
 
-    private async requestAScratchOrg(alias: string, definitionFile: string, expireIn: Duration, waitTime: Duration) {
+    private async requestAScratchOrg(alias: string, definitionFile: string, expireIn: Duration, waitTime: Duration, poolConfig: Partial<PoolConfig>) {
         const createCommandOptions: ScratchOrgRequest = {
             durationDays: expireIn.days,
             nonamespace: false,
-            noancestors: false,
+            noancestors: poolConfig.noAnchestors || false,
             wait: waitTime,
             retry: 3,
             definitionfile: definitionFile,

--- a/packages/sfp-cli/src/core/scratchorg/pool/PoolConfig.ts
+++ b/packages/sfp-cli/src/core/scratchorg/pool/PoolConfig.ts
@@ -35,6 +35,5 @@ export interface PoolConfig {
     scratchOrgs?: ScratchOrg[];
     failedToCreate?: number;
     maxRetryCount?:number;
-
-
+    noAnchestors?:boolean;
 }

--- a/packages/sfp-cli/src/core/scratchorg/pool/PoolCreateImpl.ts
+++ b/packages/sfp-cli/src/core/scratchorg/pool/PoolCreateImpl.ts
@@ -145,7 +145,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
         }
         return ok(this.pool);
 
-      
+
     }
 
     private async computeAllocation(): Promise<number> {
@@ -198,7 +198,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
         const startTime = Date.now();
         for (let i = 1; i <= pool.to_allocate; i++) {
             const scratchOrgPromise: Promise<ScratchOrg> = scratchOrgCreationLimiter.schedule(() =>
-                scratchOrgOperator.create(`SO` + i, this.pool.configFilePath, this.pool.expiry, this.pool.waitTime)
+                scratchOrgOperator.create(`SO` + i, this.pool.configFilePath, this.pool.expiry, this.pool.waitTime, this.pool)
             );
             scratchOrgPromises.push(scratchOrgPromise);
         }


### PR DESCRIPTION
Hi @azlam-abdulsalam 

While I was at it, I immediately implemented the feature. I wrote the option in the pool config file, so we are a bit more flexible compared to a new flag. Documentation update will follow when I have the authorization for sfp-docs. 

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/sfp-docs) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

