### PR TITLE
fix: compare against classnames without namespace

### DIFF
--- a/packages/sfp-cli/src/core/apextest/TriggerApexTests.ts
+++ b/packages/sfp-cli/src/core/apextest/TriggerApexTests.ts
@@ -370,7 +370,9 @@ export default class TriggerApexTests {
                         (this.coverageOptions.isPackageCoverageToBeValidated ||
                             this.coverageOptions.isIndividualClassCoverageToBeValidated)
                     ) {
-                        if (!testToBeTriggered.includes(test.apexClass.fullName)) {
+                        let apexClassParts = test.apexClass.fullName.split(".");
+                        let apexClassNameWithoutPotentialNamespace = apexClassParts[apexClassParts.length - 1];
+                        if (!testToBeTriggered.includes(apexClassNameWithoutPotentialNamespace)) {
                             testClassesThatDonotContributedCoverage.push(test.apexClass.fullName);
                             if (!testToBeTriggered.includes(test.apexClass.fullName))
                                 testToBeTriggered.push(test.apexClass.fullName);
@@ -453,7 +455,7 @@ export default class TriggerApexTests {
                 if (isCoverageToBeFetched) {
                     const mergedCodecoverage: CodeCoverageResult[] = modifiedTestResult.codecoverage;
                     for (const codeCoverageObject of secondTestResult.codecoverage){
-                    
+
                         const index = mergedCodecoverage.findIndex((codeCoverage) => codeCoverage.name === codeCoverageObject.name);
                         if (index !== -1) {
                             mergedCodecoverage[index] = codeCoverageObject;


### PR DESCRIPTION
- could cause collision issue if there is a namespace class named the same as an unnamespaced class, but this still represents an improvement over current state

Related to issue/12




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/sfp-docs) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

