### PR TITLE
feat(release): enhanced support for multiple release definitions in release command

### DIFF
--- a/packages/sfp-cli/src/commands/orchestrator/release.ts
+++ b/packages/sfp-cli/src/commands/orchestrator/release.ts
@@ -263,7 +263,7 @@ export default class Release extends SfpCommand {
             );
         }
 
-        SFPLogger.log(COLOR_TIME(`\nElapsed Time: ${new Date(totalElapsedTime).toISOString().substring(11, 8)}`));
+        SFPLogger.log(COLOR_TIME(`\nElapsed Time: ${new Date(totalElapsedTime).toISOString().substring(11,19)}`));
         SFPLogger.printHeaderLine('', COLOR_HEADER, LoggerLevel.INFO);
     }
 

--- a/packages/sfp-cli/src/commands/orchestrator/release.ts
+++ b/packages/sfp-cli/src/commands/orchestrator/release.ts
@@ -15,7 +15,13 @@ import SFPLogger, {
     ConsoleLogger,
 } from '@flxblio/sfp-logger';
 import ReleaseDefinition from '../../impl/release/ReleaseDefinition';
-import { arrayFlagSfdxStyle, loglevel, logsgroupsymbol, optionalDevHubFlag, requiredUserNameFlag } from '../../flags/sfdxflags';
+import {
+    arrayFlagSfdxStyle,
+    loglevel,
+    logsgroupsymbol,
+    optionalDevHubFlag,
+    requiredUserNameFlag,
+} from '../../flags/sfdxflags';
 import { Flags } from '@oclif/core';
 
 Messages.importMessagesDirectory(__dirname);
@@ -91,16 +97,16 @@ export default class Release extends SfpCommand {
         allowunpromotedpackages: Flags.boolean({
             description: messages.getMessage('allowUnpromotedPackagesFlagDescription'),
             hidden: true,
-            deprecated: { 
+            deprecated: {
                 message: '--allowunpromotedpackages is deprecated, All packages are allowed',
-             },
+            },
         }),
         changelogByDomains: Flags.boolean({
             description: messages.getMessage('changelogByDomainsFlagDescription'),
-            hidden: true
+            hidden: true,
         }),
         devhubalias: optionalDevHubFlag,
-        loglevel
+        loglevel,
     };
 
     public async execute() {
@@ -121,15 +127,14 @@ export default class Release extends SfpCommand {
         SFPLogger.log(COLOR_HEADER(`Release Definitions: ${this.flags.releasedefinition}`));
         SFPLogger.log(COLOR_HEADER(`Artifact Directory: ${path.resolve('artifacts')}`));
 
-        SFPLogger.printHeaderLine('',COLOR_HEADER,LoggerLevel.INFO);
+        SFPLogger.printHeaderLine('', COLOR_HEADER, LoggerLevel.INFO);
 
         let releaseDefinitions: ReleaseDefinition[] = [];
         for (const pathToReleaseDefintion of this.flags.releasedefinition) {
             let releaseDefinition = await ReleaseDefinitionLoader.loadReleaseDefinition(pathToReleaseDefintion);
 
             //Support Legacy by taking the existing single workItemFilter and pushing it to the new model
-            if(releaseDefinition.changelog?.workItemFilter)
-            {
+            if (releaseDefinition.changelog?.workItemFilter) {
                 releaseDefinition.changelog.workItemFilters = new Array<string>();
                 releaseDefinition.changelog.workItemFilters.push(releaseDefinition.changelog?.workItemFilter);
             }
@@ -164,21 +169,19 @@ export default class Release extends SfpCommand {
                 isGenerateChangelog: this.flags.generatechangelog,
                 devhubUserName: this.flags.devhubalias,
                 branch: this.flags.branchname,
-                directory:this.flags.directory,
+                directory: this.flags.directory,
             };
 
-            let releaseImpl: ReleaseImpl = new ReleaseImpl(props,new ConsoleLogger());
+            let releaseImpl: ReleaseImpl = new ReleaseImpl(props, new ConsoleLogger());
 
             releaseResult = await releaseImpl.exec();
-            if(!this.flags.dryrun)
-             SFPStatsSender.logCount('release.succeeded', tags);
+            if (!this.flags.dryrun) SFPStatsSender.logCount('release.succeeded', tags);
         } catch (err) {
             if (err instanceof ReleaseError) {
                 releaseResult = err.data;
             } else SFPLogger.log(err.message);
 
-            if(!this.flags.dryrun)
-              SFPStatsSender.logCount('release.failed', tags);
+            if (!this.flags.dryrun) SFPStatsSender.logCount('release.failed', tags);
 
             // Fail the task when an error occurs
             process.exitCode = 1;
@@ -193,8 +196,7 @@ export default class Release extends SfpCommand {
     }
 
     private sendMetrics(releaseResult: ReleaseResult, tags: any, totalElapsedTime: number) {
-        if(!this.flags.dryrun)
-        {
+        if (!this.flags.dryrun) {
             SFPStatsSender.logCount('release.scheduled', tags);
 
             SFPStatsSender.logGauge('release.duration', totalElapsedTime, tags);
@@ -223,8 +225,8 @@ export default class Release extends SfpCommand {
     private printReleaseSummary(releaseResult: ReleaseResult, totalElapsedTime: number): void {
         if (this.flags.logsgroupsymbol?.[0])
             SFPLogger.log(COLOR_HEADER(this.flags.logsgroupsymbol[0], 'Release Summary'));
-        
-        SFPLogger.printHeaderLine('',COLOR_HEADER,LoggerLevel.INFO);
+
+        SFPLogger.printHeaderLine('', COLOR_HEADER, LoggerLevel.INFO);
         if (releaseResult.installDependenciesResult) {
             SFPLogger.log(COLOR_HEADER(`\nPackage Dependencies`));
             SFPLogger.log(COLOR_SUCCESS(`   ${releaseResult.installDependenciesResult.success.length} succeeded`));
@@ -233,13 +235,25 @@ export default class Release extends SfpCommand {
         }
 
         for (const succeededDeployment of releaseResult.succeededDeployments) {
-            SFPLogger.log(COLOR_HEADER(`\n Release Defintion: ${succeededDeployment.releaseDefinition.release}`));
+            SFPLogger.log(
+                COLOR_HEADER(
+                    `\n Release Defintion: ${succeededDeployment.releaseDefinition.release} for Release Config: ${
+                        succeededDeployment.releaseDefinition.releaseConfigName
+                            ? succeededDeployment.releaseDefinition.releaseConfigName
+                            : 'N/A'
+                    }`
+                )
+            );
             SFPLogger.log(COLOR_SUCCESS(`   ${succeededDeployment.result.deployed.length} succeeded`));
             SFPLogger.log(COLOR_ERROR(`   ${succeededDeployment.result.failed.length} failed`));
         }
 
         for (const failedDeployment of releaseResult.failedDeployments) {
-            SFPLogger.log(COLOR_HEADER(`\n Release Defintion: ${failedDeployment.releaseDefinition.release}`));
+            SFPLogger.log(COLOR_HEADER(`\n Release Defintion: ${failedDeployment.releaseDefinition.release} for for Release Config: ${
+                failedDeployment.releaseDefinition.releaseConfigName
+                    ? failedDeployment.releaseDefinition.releaseConfigName
+                    : 'N/A'
+            }`));
             SFPLogger.log(COLOR_SUCCESS(`   ${failedDeployment.result.deployed.length} succeeded`));
             SFPLogger.log(
                 COLOR_ERROR(
@@ -249,12 +263,11 @@ export default class Release extends SfpCommand {
             );
         }
 
-        SFPLogger.log(COLOR_TIME(`\nElapsed Time: ${new Date(totalElapsedTime).toISOString().substr(11, 8)}`));
-        SFPLogger.printHeaderLine('',COLOR_HEADER,LoggerLevel.INFO);
+        SFPLogger.log(COLOR_TIME(`\nElapsed Time: ${new Date(totalElapsedTime).toISOString().substring(11, 8)}`));
+        SFPLogger.printHeaderLine('', COLOR_HEADER, LoggerLevel.INFO);
     }
 
     protected validateFlags() {
         if (this.flags.npm && !this.flags.scope) throw new Error('--scope parameter is required for NPM');
-
     }
 }

--- a/packages/sfp-cli/src/core/package/dependencies/PackageDependencyResolver.ts
+++ b/packages/sfp-cli/src/core/package/dependencies/PackageDependencyResolver.ts
@@ -46,7 +46,7 @@ export default class PackageDependencyResolver {
                     let dependency = packageDirectory.dependencies[i];
                     if (this.projectConfig.packageAliases[dependency.package] === undefined && !this.isSubscriberPackageVersionId(dependency.package)) {
                         
-                        throw new Error(`Can't find package id for dependency: ` + dependency.package);
+                        throw new Error(`Can't find package id for dependency: ${dependency.package}, Please ensure that the package is added to sfdx-project.json in your packageAliases`);
                     }
 
                     let packageVersionId = this.isSubscriberPackageVersionId(dependency.package)?dependency.package:this.projectConfig.packageAliases[dependency.package]
@@ -211,7 +211,8 @@ export default class PackageDependencyResolver {
 
         if (!package2VersionOnCurrentBranch) {
             throw new Error(
-                `Failed to find validated Package2 version for dependency ${dependency.package} with version ${dependency.versionNumber} created from the current branch`
+                `Failed to find validated Package2 version for dependency ${dependency.package} with version ${dependency.versionNumber} created from the current branch, 
+                 You will need to create a new version of the package on the current branch to resolve this dependency.`
             );
         }
 

--- a/packages/sfp-cli/src/impl/impact/ImpactedReleaseConfig.ts
+++ b/packages/sfp-cli/src/impl/impact/ImpactedReleaseConfig.ts
@@ -5,7 +5,7 @@ import path from 'path';
 export default class ImpactedRelaseConfigResolver {
 
     public getImpactedReleaseConfigs(impactedPackages, configDir,isExplicitDependencyCheckEnabled:boolean=false, filterBy?: string) {
-        const impactedReleaseDefs = [];
+        const impactedReleaseConfigs = [];
 
         fs.readdirSync(configDir).forEach((file) => {
             const filePath = path.join(configDir, file);
@@ -38,7 +38,7 @@ export default class ImpactedRelaseConfigResolver {
                 if (releaseImpactedPackages.length > 0) {
                     if (filterBy) {
                         if (releaseConfig.releaseName.includes(filterBy)) {
-                            impactedReleaseDefs.push({
+                            impactedReleaseConfigs.push({
                                 releaseName: releaseConfig.releaseName,
                                 pool: releaseConfig.pool
                                     ? releaseConfig.pool
@@ -48,7 +48,7 @@ export default class ImpactedRelaseConfigResolver {
                             });
                         }
                     } else {
-                        impactedReleaseDefs.push({
+                        impactedReleaseConfigs.push({
                             releaseName: releaseConfig.releaseName,
                             pool: releaseConfig.pool
                                 ? releaseConfig.pool
@@ -61,7 +61,7 @@ export default class ImpactedRelaseConfigResolver {
             }
         });
 
-        const sortedImpactedReleaseDefs = impactedReleaseDefs.sort((a, b) => {
+        const sortedImpactedReleaseConfigs = impactedReleaseConfigs.sort((a, b) => {
             if (!a.impactedPackages.length && !b.impactedPackages.length) return 0;
             if (!a.impactedPackages.length) return 1; // Move releases with no impacted packages to the end
             if (!b.impactedPackages.length) return -1; // Same as above
@@ -77,7 +77,7 @@ export default class ImpactedRelaseConfigResolver {
         });
 
         const output = {
-            include: sortedImpactedReleaseDefs,
+            include: sortedImpactedReleaseConfigs,
         };
         return output;
     }

--- a/packages/sfp-cli/src/impl/release/ReleaseDefinitionSorter.ts
+++ b/packages/sfp-cli/src/impl/release/ReleaseDefinitionSorter.ts
@@ -1,0 +1,45 @@
+import { Logger } from '@flxblio/sfp-logger';
+import SfpPackageInquirer from '../../core/package/SfpPackageInquirer';
+import ProjectConfig from '../../core/project/ProjectConfig';
+import ArtifactFetcher, { Artifact } from '../../core/artifacts/ArtifactFetcher';
+import SfpPackage from '../../core/package/SfpPackage';
+import SfpPackageBuilder from '../../core/package/SfpPackageBuilder';
+import ReleaseDefinition from './ReleaseDefinition';
+import _ from 'lodash';
+
+export default class ReleaseDefinitionSorter {
+
+    public sortReleaseDefinitions(
+        releaseDefinitions: ReleaseDefinition[],
+        leadingSfProjectConfig: any,
+        logger: Logger
+    ): ReleaseDefinition[] {
+
+        let clonedReleaseDefintions:ReleaseDefinition[] = _.cloneDeep(releaseDefinitions);
+        const allPackagesInConfig = ProjectConfig.getAllPackagesFromProjectConfig(leadingSfProjectConfig);
+        const packageOccurrenceCount = new Map<string, number>();
+
+        // Count occurrences of each package across all release definitions
+        clonedReleaseDefintions.forEach((releaseDefinition) => {
+            Object.keys(releaseDefinition.artifacts).forEach((pkg) => {
+                if (allPackagesInConfig.includes(pkg)) {
+                    // Only consider packages present in the project config
+                    packageOccurrenceCount.set(pkg, (packageOccurrenceCount.get(pkg) || 0) + 1);
+                }
+            });
+        });
+        // Annotate each release definition with the index of its first unique package
+        clonedReleaseDefintions.forEach((releasedefnition) => {
+            releasedefnition['firstUniquePackageIndex'] = allPackagesInConfig.length; // Default to length (i.e., end) if no unique package is found
+            for (const pkg of allPackagesInConfig) {
+                if (releasedefnition.artifacts[pkg] && packageOccurrenceCount.get(pkg) === 1) {
+                    // Check if the package is unique
+                    releasedefnition['firstUniquePackageIndex'] = allPackagesInConfig.indexOf(pkg);
+                    break; // Found the first unique package, no need to continue
+                }
+            }
+        });
+        // Sort based on the first unique package's index, placing those without a unique package at the end
+        return clonedReleaseDefintions.sort((a, b) => a['firstUniquePackageIndex'] - b['firstUniquePackageIndex']);
+    }
+}

--- a/packages/sfp-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfp-cli/src/impl/release/ReleaseImpl.ts
@@ -1,6 +1,6 @@
 import ReleaseDefinition from './ReleaseDefinition';
 import DeployImpl, { DeployProps, DeploymentMode, DeploymentResult } from '../deploy/DeployImpl';
-import SFPLogger, { COLOR_HEADER, COLOR_KEY_MESSAGE, ConsoleLogger, Logger, LoggerLevel } from '@flxblio/sfp-logger';
+import SFPLogger, { COLOR_HEADER, COLOR_INFO, COLOR_KEY_MESSAGE, ConsoleLogger, Logger, LoggerLevel } from '@flxblio/sfp-logger';
 import { Stage } from '../Stage';
 import ReleaseError from '../../errors/ReleaseError';
 import ChangelogImpl from '../changelog/ChangelogImpl';
@@ -12,7 +12,12 @@ import { EOL } from 'os';
 import Package2Detail from '../../core/package/Package2Detail';
 import InstallUnlockedPackageCollection from '../../core/package/packageInstallers/InstallUnlockedPackageCollection';
 import FetchImpl from '../artifacts/FetchImpl';
-import GroupConsoleLogs  from '../../ui/GroupConsoleLogs';
+import GroupConsoleLogs from '../../ui/GroupConsoleLogs';
+import ArtifactFetcher, { Artifact } from '../../core/artifacts/ArtifactFetcher';
+import SfpPackage from '../../core/package/SfpPackage';
+import SfpPackageBuilder from '../../core/package/SfpPackageBuilder';
+import SfpPackageInquirer from '../../core/package/SfpPackageInquirer';
+import ReleaseDefinitionSorter from './ReleaseDefinitionSorter';
 
 export interface ReleaseProps {
     releaseDefinitions: ReleaseDefinition[];
@@ -32,6 +37,11 @@ export interface ReleaseProps {
     directory: string;
 }
 
+type DeploymentStatus = {
+    releaseDefinition: ReleaseDefinition;
+    result: DeploymentResult;
+};
+
 export default class ReleaseImpl {
     constructor(private props: ReleaseProps, private logger?: Logger) {}
 
@@ -45,6 +55,13 @@ export default class ReleaseImpl {
             this.logger
         );
         await fetchImpl.fetchArtifacts(this.props.releaseDefinitions);
+
+        SFPLogger.log(COLOR_INFO(`Sorting order of release definitions...`), LoggerLevel.INFO, this.logger);
+        const sortedReleaseDefns = await this.getSortedReleaseDefns('artifacts',this.props.releaseDefinitions, this.logger);
+        const sortedReleaseOrder = sortedReleaseDefns.map((def) => def.release);
+        SFPLogger.log(COLOR_KEY_MESSAGE(`Order of  Release Definitions: ${JSON.stringify(sortedReleaseOrder)}`), LoggerLevel.INFO, this.logger);
+
+
         groupSection.end();
 
         let installDependenciesResult: InstallDependenciesResult;
@@ -55,11 +72,12 @@ export default class ReleaseImpl {
             this.props.waitTime
         );
 
-        let deploymentResults = await this.deployArtifacts(this.props.releaseDefinitions);
+      
+        let deploymentResults = await this.deployArtifacts(sortedReleaseDefns);
 
         //Get all suceeded deploys
-        let succeededDeploymentResults = [];
-        let failedDeploymentResults = [];
+        let succeededDeploymentResults: DeploymentStatus[] = [];
+        let failedDeploymentResults: DeploymentStatus[] = [];
         for (const deploymentResult of deploymentResults) {
             if (deploymentResult.result.failed.length === 0) succeededDeploymentResults.push(deploymentResult);
             else failedDeploymentResults.push(deploymentResult);
@@ -76,62 +94,69 @@ export default class ReleaseImpl {
             let limit = 30;
             let workItemUrl: string;
             let showAllArtifacts: boolean = false;
-            for (const releaseDefinition of this.props.releaseDefinitions) {
-                releaseName = releaseName.concat(releaseDefinition.release, '-');
+
+            //Lets go through all the succeeded deployments and get the changelog
+            for (const succededDeployment of succeededDeploymentResults) {
+                releaseName = succededDeployment.releaseDefinition.release;
+                let releaseDefinition = succededDeployment.releaseDefinition;
                 if (releaseDefinition.changelog) {
-                    if(releaseDefinition.changelog.workItemFilters) {
-                       workitemFilters.push(...releaseDefinition.changelog?.workItemFilters);
+                    if (releaseDefinition.changelog.workItemFilters) {
+                        workitemFilters.push(...releaseDefinition.changelog?.workItemFilters);
                     }
                     if (releaseDefinition.changelog.limit > limit) limit = releaseDefinition.changelog.limit;
                     workItemUrl = releaseDefinition.changelog.workItemUrl;
                     showAllArtifacts = releaseDefinition.changelog.showAllArtifacts;
                 }
-            }
-            //Remove the last '-' from the name
-            releaseName = releaseName.slice(0, -1);
-            if (this.props.isGenerateChangelog) {
-                let groupSection = new GroupConsoleLogs('Release changelog').begin();
-                try {
-                    let changelogImpl: ChangelogImpl = new ChangelogImpl(
-                        this.logger,
-                        'artifacts',
-                        releaseName,
-                        workitemFilters,
-                        limit,
-                        workItemUrl,
-                        showAllArtifacts,
-                        this.props.directory,
-                        false,
-                        this.props.branch,
-                        false,
-                        this.props.isDryRun,
-                        this.props.targetOrg
-                    );
 
-                    let releaseChangelog = await changelogImpl.exec();
+                if (this.props.isGenerateChangelog) {
+                    let groupSection = new GroupConsoleLogs('Release changelog').begin();
+                    try {
+                        let changelogImpl: ChangelogImpl = new ChangelogImpl(
+                            this.logger,
+                            'artifacts',
+                            releaseName,
+                            workitemFilters,
+                            limit,
+                            workItemUrl,
+                            showAllArtifacts,
+                            releaseDefinition.releaseConfigName
+                                ? path.join(this.props.directory, releaseDefinition.releaseConfigName)
+                                : this.props.directory,
+                            false,
+                            this.props.branch,
+                            false,
+                            this.props.isDryRun,
+                            this.props.targetOrg
+                        );
 
-                    const aggregatedNumberOfWorkItemsInRelease = this.getAggregatedNumberOfWorkItemsInRelease(
-                        releaseName,
-                        releaseChangelog.releases
-                    );
+                        let releaseChangelog = await changelogImpl.exec();
 
-                    SFPStatsSender.logGauge('release.workitems', aggregatedNumberOfWorkItemsInRelease, {
-                        releaseName: releaseName,
-                    });
+                        const aggregatedNumberOfWorkItemsInRelease = this.getAggregatedNumberOfWorkItemsInRelease(
+                            releaseName,
+                            releaseChangelog.releases
+                        );
 
-                    const aggregatedNumberOfCommitsInRelease = this.getAggregatedNumberOfCommitsInRelease(
-                        releaseName,
-                        releaseChangelog.releases
-                    );
+                        SFPStatsSender.logGauge('release.workitems', aggregatedNumberOfWorkItemsInRelease, {
+                            releaseName: releaseName,
+                            domain: releaseDefinition.releaseConfigName,
+                        });
 
-                    SFPStatsSender.logGauge('release.commits', aggregatedNumberOfCommitsInRelease, {
-                        releaseName: releaseName,
-                    });
-                } catch (error) {
-                    SFPLogger.log(`Unable to push changelog`, LoggerLevel.WARN, this.logger);
+                        const aggregatedNumberOfCommitsInRelease = this.getAggregatedNumberOfCommitsInRelease(
+                            releaseName,
+                            releaseChangelog.releases
+                        );
+
+                        SFPStatsSender.logGauge('release.commits', aggregatedNumberOfCommitsInRelease, {
+                            releaseName: releaseName,
+                            domain: releaseDefinition.releaseConfigName,
+                        });
+                    } catch (error) {
+                        SFPLogger.log(`Unable to push changelog`, LoggerLevel.WARN, this.logger);
+                        SFPLogger.log(error, LoggerLevel.TRACE, this.logger);
+                    }
+
+                    groupSection.end();
                 }
-
-                groupSection.end();
             }
         }
 
@@ -194,12 +219,12 @@ export default class ReleaseImpl {
         return numberOfCommits;
     }
 
-    private async deployArtifacts(
-        releaseDefinitions: ReleaseDefinition[]
-    ): Promise<{ releaseDefinition: ReleaseDefinition; result: DeploymentResult }[]> {
+  
+
+    private async deployArtifacts(releaseDefinitions: ReleaseDefinition[]): Promise<DeploymentStatus[]> {
         let deploymentResults: { releaseDefinition: ReleaseDefinition; result: DeploymentResult }[] = [];
         for (const releaseDefinition of releaseDefinitions) {
-            let groupSection = new GroupConsoleLogs(`Release ${releaseDefinition.release}`).begin();
+            let groupSection = new GroupConsoleLogs(`Release ${releaseDefinition.release} for Release Configuration: ${releaseDefinition.releaseConfigName}`).begin();
             SFPLogger.log(EOL);
 
             this.displayReleaseInfo(releaseDefinition, this.props);
@@ -222,7 +247,9 @@ export default class ReleaseImpl {
                 currentStage: Stage.DEPLOY,
                 baselineOrg: releaseDefinition.baselineOrg,
                 isDryRun: this.props.isDryRun,
-                disableArtifactCommit: releaseDefinition.skipArtifactUpdate?releaseDefinition.skipArtifactUpdate:false,
+                disableArtifactCommit: releaseDefinition.skipArtifactUpdate
+                    ? releaseDefinition.skipArtifactUpdate
+                    : false,
                 promotePackagesBeforeDeploymentToOrg: releaseDefinition.promotePackagesBeforeDeploymentToOrg,
                 devhubUserName: this.props.devhubUserName,
             };
@@ -237,6 +264,29 @@ export default class ReleaseImpl {
         }
 
         return deploymentResults;
+    }
+
+    private async getSortedReleaseDefns(artifactDirectory: string,releaseDefns:ReleaseDefinition[], logger: Logger): Promise<any> {
+        let artifacts = ArtifactFetcher.fetchArtifacts(artifactDirectory, null, logger);
+        if (artifacts.length === 0) throw new Error(`No artifacts to deploy found in ${artifactDirectory}`);
+
+        //Convert artifacts to SfpPackages
+        let sfpPackages = await this.generateSfpPackageFromArtifacts(artifacts, logger);
+
+        let sfpPackageInquirer: SfpPackageInquirer = new SfpPackageInquirer(sfpPackages, logger);
+        let sfdxProjectConfig = sfpPackageInquirer.getLatestProjectConfig();
+       
+        let releaseDefinitionSorter = new ReleaseDefinitionSorter();
+        return releaseDefinitionSorter.sortReleaseDefinitions(releaseDefns, sfdxProjectConfig, logger);
+    }
+
+    private async generateSfpPackageFromArtifacts(artifacts: Artifact[], logger: Logger): Promise<SfpPackage[]> {
+        let sfpPackages: SfpPackage[] = [];
+        for (const artifact of artifacts) {
+            let sfpPackage = await SfpPackageBuilder.buildPackageFromArtifact(artifact, logger);
+            sfpPackages.push(sfpPackage);
+        }
+        return sfpPackages;
     }
 
     private async installPackageDependencies(
@@ -279,7 +329,11 @@ export default class ReleaseImpl {
                 externalPackage2s.push(dependendentPackage);
             }
             let sfpOrg = await SFPOrg.create({ aliasOrUsername: targetOrg });
-            let packageCollectionInstaller = new InstallUnlockedPackageCollection(sfpOrg, new ConsoleLogger(),this.props.isDryRun);
+            let packageCollectionInstaller = new InstallUnlockedPackageCollection(
+                sfpOrg,
+                new ConsoleLogger(),
+                this.props.isDryRun
+            );
             await packageCollectionInstaller.install(externalPackage2s, true, true);
 
             groupSection.end();
@@ -320,9 +374,12 @@ export default class ReleaseImpl {
     }
 
     private displayReleaseInfo(releaseDefinition: ReleaseDefinition, props: ReleaseProps) {
-        SFPLogger.printHeaderLine('',COLOR_HEADER,LoggerLevel.INFO);
+        SFPLogger.printHeaderLine('', COLOR_HEADER, LoggerLevel.INFO);
 
         SFPLogger.log(COLOR_KEY_MESSAGE(`Release: ${releaseDefinition.release}`));
+        if (releaseDefinition.releaseConfigName) {
+            SFPLogger.log(COLOR_KEY_MESSAGE(`Release Config Name: ${releaseDefinition.releaseConfigName}`));
+        }
 
         SFPLogger.log(
             COLOR_KEY_MESSAGE(
@@ -331,17 +388,17 @@ export default class ReleaseImpl {
         );
 
         SFPLogger.log(COLOR_KEY_MESSAGE(`Dry-run: ${props.isDryRun}`));
-        
+
         if (releaseDefinition.baselineOrg)
             SFPLogger.log(COLOR_KEY_MESSAGE(`Baselined Against Org: ${releaseDefinition.baselineOrg}`));
-       
+
         if (
             releaseDefinition.promotePackagesBeforeDeploymentToOrg &&
             releaseDefinition.promotePackagesBeforeDeploymentToOrg == props.targetOrg
         )
             SFPLogger.log(COLOR_KEY_MESSAGE(`Promte Packages Before Deployment Activated?: true`));
 
-         SFPLogger.printHeaderLine('',COLOR_HEADER,LoggerLevel.INFO);
+        SFPLogger.printHeaderLine('', COLOR_HEADER, LoggerLevel.INFO);
     }
 }
 

--- a/packages/sfp-cli/src/impl/release/ReleaseImpl.ts
+++ b/packages/sfp-cli/src/impl/release/ReleaseImpl.ts
@@ -120,8 +120,8 @@ export default class ReleaseImpl {
                             workItemUrl,
                             showAllArtifacts,
                             releaseDefinition.releaseConfigName
-                                ? path.join(this.props.directory, releaseDefinition.releaseConfigName)
-                                : this.props.directory,
+                                ? path.join(this.props.directory?this.props.directory:"", releaseDefinition.releaseConfigName)
+                                : this.props.directory?this.props.directory:"",
                             false,
                             this.props.branch,
                             false,

--- a/packages/sfp-cli/tests/impl/release/ReleaseDefinitionSorter.test.ts
+++ b/packages/sfp-cli/tests/impl/release/ReleaseDefinitionSorter.test.ts
@@ -1,0 +1,169 @@
+import { ConsoleLogger } from '@flxblio/sfp-logger';
+import ReleaseDefinitionSorter from '../../../src/impl/release/ReleaseDefinitionSorter'; // Adjust the import path to where your function is defined
+import { expect } from '@jest/globals';
+
+describe('Sort Release Definitions by leading project config', () => {
+    it('should sort release definitions when packages are shared', async () => {
+        // Mock input data
+        const releaseDefinitions = [
+            {
+                release: 'Release1',
+                artifacts: { PackageB: '1.0.0', PackageC: '1.0.0' },
+                skipIfAlreadyInstalled: false,
+                skipArtifactUpdate: false,
+            },
+            {
+                release: 'Release2',
+                artifacts: { PackageA: '1.0.0', PackageB: '1.0.0', PackageD: '1.0.0' },
+                skipIfAlreadyInstalled: false,
+                skipArtifactUpdate: false,
+            },
+            {
+                release: 'Release3',
+                artifacts: { PackageE: '1.0.0' },
+                skipIfAlreadyInstalled: false,
+                skipArtifactUpdate: false,
+            },
+        ];
+        const leadingSfProjectConfig = {
+            packageDirectories: [
+                { package: 'PackageA', versionNumber: '1.0.0' },
+                { package: 'PackageB', versionNumber: '1.0.0' },
+                { package: 'PackageC', versionNumber: '1.0.0' },
+                { package: 'PackageD', versionNumber: '1.0.0' },
+                { package: 'PackageE', versionNumber: '1.0.0' },
+            ],
+        };
+
+        // Call the function to test
+        const sortedReleaseDefinitions = await new ReleaseDefinitionSorter().sortReleaseDefinitions(
+            releaseDefinitions,
+            leadingSfProjectConfig,
+            new ConsoleLogger()
+        );
+
+        const sortedReleaseOrder = sortedReleaseDefinitions.map((def) => def.release);
+        const expectedReleaseOrder = ['Release2', 'Release1', 'Release3'];
+        expect(sortedReleaseOrder).toEqual(expectedReleaseOrder);
+    });
+
+    it('should sort release definitions when the first release definition has the last package and packages are shared', async () => {
+        // Mock input data
+        const releaseDefinitions = [
+            {
+                release: 'Release3',
+                artifacts: { PackageE: '1.0.0' },
+                skipIfAlreadyInstalled: false,
+                skipArtifactUpdate: false,
+            },
+            {
+                release: 'Release2',
+                artifacts: { PackageA: '1.0.0', PackageB: '1.0.0', PackageC: '1.0.0' },
+                skipIfAlreadyInstalled: false,
+                skipArtifactUpdate: false,
+            },
+            {
+              release: 'Release1',
+              artifacts: { PackageB: '1.0.0' },
+              skipIfAlreadyInstalled: false,
+              skipArtifactUpdate: false,
+          },
+        ];
+        const leadingSfProjectConfig = {
+            packageDirectories: [
+                { package: 'PackageA', versionNumber: '1.0.0' },
+                { package: 'PackageB', versionNumber: '1.0.0' },
+                { package: 'PackageC', versionNumber: '1.0.0' },
+                { package: 'PackageD', versionNumber: '1.0.0' },
+                { package: 'PackageE', versionNumber: '1.0.0' },
+            ],
+        };
+
+        // Call the function to test
+        const sortedReleaseDefinitions = await new ReleaseDefinitionSorter().sortReleaseDefinitions(
+            releaseDefinitions,
+            leadingSfProjectConfig,
+            new ConsoleLogger()
+        );
+
+        const sortedReleaseOrder = sortedReleaseDefinitions.map((def) => def.release);
+        const expectedReleaseOrder = ['Release2', 'Release3', 'Release1'];
+        expect(sortedReleaseOrder).toEqual(expectedReleaseOrder);
+    });
+
+    it('should return the same definition when only one is provided', async () => {
+      // Mock input data
+      const releaseDefinitions = [
+          {
+              release: 'Release3',
+              artifacts: { PackageE: '1.0.0' },
+              skipIfAlreadyInstalled: false,
+              skipArtifactUpdate: false,
+          }
+      ];
+      const leadingSfProjectConfig = {
+          packageDirectories: [
+              { package: 'PackageA', versionNumber: '1.0.0' },
+              { package: 'PackageB', versionNumber: '1.0.0' },
+              { package: 'PackageC', versionNumber: '1.0.0' },
+              { package: 'PackageD', versionNumber: '1.0.0' },
+              { package: 'PackageE', versionNumber: '1.0.0' },
+          ],
+      };
+
+      // Call the function to test
+      const sortedReleaseDefinitions = await new ReleaseDefinitionSorter().sortReleaseDefinitions(
+          releaseDefinitions,
+          leadingSfProjectConfig,
+          new ConsoleLogger()
+      );
+
+      const sortedReleaseOrder = sortedReleaseDefinitions.map((def) => def.release);
+      const expectedReleaseOrder = ['Release3'];
+      expect(sortedReleaseOrder).toEqual(expectedReleaseOrder);
+    });
+
+    it('should sort release definitions when no packages are shared', async () => {
+      // Mock input data
+      const releaseDefinitions = [
+          {
+              release: 'Release3',
+              artifacts: { PackageE: '1.0.0' },
+              skipIfAlreadyInstalled: false,
+              skipArtifactUpdate: false,
+          },
+          {
+              release: 'Release2',
+              artifacts: { PackageA: '1.0.0', PackageB: '1.0.0' },
+              skipIfAlreadyInstalled: false,
+              skipArtifactUpdate: false,
+          },
+          {
+            release: 'Release1',
+            artifacts: { PackageC: '1.0.0' },
+            skipIfAlreadyInstalled: false,
+            skipArtifactUpdate: false,
+        },
+      ];
+      const leadingSfProjectConfig = {
+          packageDirectories: [
+              { package: 'PackageA', versionNumber: '1.0.0' },
+              { package: 'PackageB', versionNumber: '1.0.0' },
+              { package: 'PackageC', versionNumber: '1.0.0' },
+              { package: 'PackageD', versionNumber: '1.0.0' },
+              { package: 'PackageE', versionNumber: '1.0.0' },
+          ],
+      };
+
+      // Call the function to test
+      const sortedReleaseDefinitions = await new ReleaseDefinitionSorter().sortReleaseDefinitions(
+          releaseDefinitions,
+          leadingSfProjectConfig,
+          new ConsoleLogger()
+      );
+
+      const sortedReleaseOrder = sortedReleaseDefinitions.map((def) => def.release);
+      const expectedReleaseOrder = ['Release2', 'Release1', 'Release3'];
+      expect(sortedReleaseOrder).toEqual(expectedReleaseOrder);
+  });
+});


### PR DESCRIPTION
Adds enhanced support for multiple release defns as an input

This change allows for a single release command to support multiple release defns from different
configurations, It will use a leading order from one of the artifacts to determine the order of
executing releases

BREAKING CHANGE: changelog will be written for each release config by computing the name, and will
be pushed individually



#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/sfp-docs) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

