### PR TITLE
feat(new validate flag): run  tests only for source changes

### DIFF
--- a/packages/sfp-cli/messages/validate.json
+++ b/packages/sfp-cli/messages/validate.json
@@ -21,6 +21,6 @@
     "orgInfoFlagDescription": "Display info about the org that is used for validation",
     "installDepsFlagDescription":"Install dependencies during fast feedback",
     "disableSourcePackageOverride": "Disables overriding unlocked package installation as source package installation during validate",
-    "disableParallelTestingFlagDescription": "Disable test execution in parallel, this will execute apex tests in serial"
-    
+    "disableParallelTestingFlagDescription": "Disable test execution in parallel, this will execute apex tests in serial",
+    "runTestAgainstSourceFlagDescription": "Enable impact testing, this will only run tests for the components that are impacted by the source changes"
 }

--- a/packages/sfp-cli/messages/validateAgainstOrg.json
+++ b/packages/sfp-cli/messages/validateAgainstOrg.json
@@ -12,5 +12,6 @@
     "disableSourcePackageOverride": "Disables overriding unlocked package installation as source package installation during validate",
     "disableParallelTestingFlagDescription": "Disable test execution in parallel, this will execute apex tests in serial",
     "installDepsFlagDescription":"Install dependencies during fast feedback",
-    "orgInfoFlagDescription": "Display info about the org that is used for validation"
+    "orgInfoFlagDescription": "Display info about the org that is used for validation",
+    "runTestAgainstSourceFlagDescription": "Enable impact testing, this will only run tests for the components that are impacted by the source changes"
 }

--- a/packages/sfp-cli/src/commands/orchestrator/validate.ts
+++ b/packages/sfp-cli/src/commands/orchestrator/validate.ts
@@ -92,6 +92,11 @@ export default class Validate extends SfpCommand {
             description: messages.getMessage('disableArtifactUpdateFlagDescription'),
             default: false,
         }),
+        runtestagainstsource: Flags.boolean({
+            description: messages.getMessage('runTestAgainstSourceFlagDescription'),
+            default: false,
+            dependsOn: ['basebranch'],
+        }),
         logsgroupsymbol,
         loglevel
     };
@@ -129,7 +134,7 @@ export default class Validate extends SfpCommand {
         SFPLogger.log(
             COLOR_HEADER(`Dependency Validation: ${this.flags.enabledependencyvalidation ? 'true' : 'false'}`)
         );
-       
+
 
         SFPLogger.printHeaderLine('',COLOR_HEADER,LoggerLevel.INFO);
 
@@ -157,6 +162,7 @@ export default class Validate extends SfpCommand {
                 disableSourcePackageOverride : this.flags.disablesourcepkgoverride,
                 disableParallelTestExecution: this.flags.disableparalleltesting,
                 installExternalDependencies: this.flags.installdeps,
+                runTestOnlyAgainstSource: this.flags.runtestagainstsource,
             };
 
             setReleaseConfigForReleaseBasedModes(this.flags.releaseconfig,validateProps);

--- a/packages/sfp-cli/src/commands/orchestrator/validateAgainstOrg.ts
+++ b/packages/sfp-cli/src/commands/orchestrator/validateAgainstOrg.ts
@@ -62,6 +62,11 @@ export default class ValidateAgainstOrg extends SfpCommand {
             description: messages.getMessage('disableParallelTestingFlagDescription'),
             default: false,
         }),
+        runtestagainstsource: Flags.boolean({
+            description: messages.getMessage('runTestAgainstSourceFlagDescription'),
+            default: false,
+            dependsOn: ['basebranch'],
+        }),
         loglevel
     };
 
@@ -93,11 +98,11 @@ export default class ValidateAgainstOrg extends SfpCommand {
         if (this.flags.mode != ValidationMode.FAST_FEEDBACK) {
             SFPLogger.log(COLOR_HEADER(`Coverage Percentage: ${this.flags.coveragepercent}`));
         }
-      
+
 
         SFPLogger.printHeaderLine('',COLOR_HEADER,LoggerLevel.INFO);
 
-        
+
         let validateResult: ValidateResult;
         try {
             let validateProps: ValidateProps = {
@@ -117,6 +122,7 @@ export default class ValidateAgainstOrg extends SfpCommand {
                 disableParallelTestExecution: this.flags.disableparalleltesting,
                 orgInfo: this.flags.orginfo,
                 installExternalDependencies: this.flags.installdeps,
+                runTestOnlyAgainstSource: this.flags.runtestagainstsource
             };
 
 
@@ -132,7 +138,7 @@ export default class ValidateAgainstOrg extends SfpCommand {
         } catch (error) {
             if (error instanceof ValidateError) {
                 validateResult = error.data;
-            } 
+            }
 
             SFPStatsSender.logCount('validate.failed', tags);
 


### PR DESCRIPTION
Hi @azlam-abdulsalam 

i have decided to use a new flag because it seems that some modes uses the testclass execution. 

The new flag is called ***--runtestagainstsource*** and depends on ***--basebranch*** 
Please give my a sign when everything is fine then i can update the docs.

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/sfp-docs) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?

