### PR TITLE
fix(patch): ensure path to artifact directory is correct

### DIFF
--- a/packages/sfp-cli/src/commands/repo/patch.ts
+++ b/packages/sfp-cli/src/commands/repo/patch.ts
@@ -157,6 +157,14 @@ export default class Patch extends SfpCommand {
                 'artifacts',
                 releaseDefinition.release.replace(/[/\\?%*:|"<>]/g, '-')
             );
+            if(releaseDefinition.releaseConfigName)
+            {
+                revisedArtifactDirectory = path.join(
+                    'artifacts',
+                    releaseDefinition.releaseConfigName.replace(/[/\\?%*:|"<>]/g, '-'),
+                    releaseDefinition.release.replace(/[/\\?%*:|"<>]/g, '-')
+                );
+            }
 
             let artifacts = ArtifactFetcher.fetchArtifacts(revisedArtifactDirectory, null, logger);
 


### PR DESCRIPTION
Ensure correct path to directory is used in repo patch, as this was broken in the update to support multiple release defns

https://github.com/flxbl-io/sfops-issues/issues/25