### PR TITLE
fix(apextests): fix incorrect url reference in error message

### DIFF
--- a/packages/sfp-cli/src/core/apextest/TriggerApexTests.ts
+++ b/packages/sfp-cli/src/core/apextest/TriggerApexTests.ts
@@ -162,7 +162,7 @@ export default class TriggerApexTests {
                     id: testResult.summary.testRunId,
                     message: dedent `Unable to fetch test execution results,
                               Please check the results in the org by using the URL below
-                              https://${this.conn.instanceUrl}/lightning/setup/ApexTestHistory/home
+                              ${this.conn.instanceUrl}/lightning/setup/ApexTestHistory/home
                               Please try the test execution again`,
                 };
             }


### PR DESCRIPTION
This fixes an a typo in URL used in displaying error messages

Cherry-picked commit 7967c4ce from another repository.