### PR TITLE
fix(chore): fix PR template documentation link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,6 @@ All items have to be completed before a PR is merged
 
 - [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
 - [ ] Updates to Decision Records considered?
-- [ ] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/sfp-docs) considered?
+- [ ] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/docs-sfp) considered?
 - [ ] Tested changes?
 - [ ] Unit Tests new and existing passing locally?
-


### PR DESCRIPTION
Fixed the PR link from `https://github.com/flxbl-io/sfp-docs` to `https://github.com/flxbl-io/docs-sfp`


#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/sfp-docs) considered?
- [x] Tested changes?
- [ ] Unit Tests new and existing passing locally?

