### PR TITLE
feat(pool): add password to fetched scratch org from pool

### DIFF
--- a/src/core/scratchorg/pool/PoolFetchImpl.ts
+++ b/src/core/scratchorg/pool/PoolFetchImpl.ts
@@ -216,8 +216,14 @@ export default class PoolFetchImpl extends PoolBaseImpl {
               
 
                 const oauth2Options = AuthInfo.parseSfdxAuthUrl(soDetail.sfdxAuthUrl);
-                const authInfo = await AuthInfo.create({ oauth2Options });
-                await authInfo.save({...authInfo.getFields(),isScratch:true,devHubUsername:this.hubOrg.getUsername(),expirationDate:soDetail.expiryDate});
+                const authInfo = await AuthInfo.create({oauth2Options});
+                await authInfo.save({
+                    ...authInfo.getFields(),
+                    isScratch: true,
+                    devHubUsername: this.hubOrg.getUsername(),
+                    expirationDate: soDetail.expiryDate,
+                    password: soDetail.password
+                });
 
                 await authInfo.handleAliasAndDefaultSettings({
                     alias: this.alias?this.alias:soDetail.alias,


### PR DESCRIPTION
This came as a proposal after getting stuck with this: (posted on the Slack channel)

Is there a reason why sfp doesn't persist the password in sf cli auth config after fetching a scratch org from the pool?
The reason I why I ask this is because Provar does generate a new password when it runs thus overriding the password as filled in the prod org `Password__c` field.

Reference to Provar source code: https://github.com/ProvarTesting/provardx/blob/development/src/utilities/ProvarDXUtility.ts#L112

I am thinking of figuring this out myself and providing a PR to sfp, what are your thoughts on this change?

