### PR TITLE
fix(sfppackage): fix handling of URL-encoded spaces in repository URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "dotenv": "16.3.1",
         "fast-xml-parser": "4.2.7",
         "fs-extra": "^11.1.1",
-        "git-url-parse": "14.0.0",
+        "git-url-parse": "^16.0.0",
         "glob": "^10.3.3",
         "handlebars": "^4.7.7",
         "hot-shots": "^8.5.0",
@@ -7300,20 +7300,22 @@
       }
     },
     "node_modules/git-up": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
-      "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.0.0.tgz",
+      "integrity": "sha512-uBI8Zdt1OZlrYfGcSVroLJKgyNNXlgusYFzHk614lTasz35yg2PVpL1RMy0LOO2dcvF9msYW3pRfUSmafZNrjg==",
+      "license": "MIT",
       "dependencies": {
         "is-ssh": "^1.4.0",
-        "parse-url": "^8.1.0"
+        "parse-url": "^9.2.0"
       }
     },
     "node_modules/git-url-parse": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-14.0.0.tgz",
-      "integrity": "sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.0.0.tgz",
+      "integrity": "sha512-Y8iAF0AmCaqXc6a5GYgPQW9ESbncNLOL+CeQAJRhmWUOmnPkKpBYeWYp4mFd3LA5j53CdGDdslzX12yEBVHQQg==",
+      "license": "MIT",
       "dependencies": {
-        "git-up": "^7.0.0"
+        "git-up": "^8.0.0"
       }
     },
     "node_modules/github-from-package": {
@@ -11840,11 +11842,16 @@
       }
     },
     "node_modules/parse-url": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
-      "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
+      "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
+      "license": "MIT",
       "dependencies": {
+        "@types/parse-path": "^7.0.0",
         "parse-path": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.0"
       }
     },
     "node_modules/pascal-case": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dotenv": "16.3.1",
     "fast-xml-parser": "4.5.0",
     "fs-extra": "^11.1.1",
-    "git-url-parse": "14.0.0",
+    "git-url-parse": "^16.0.0",
     "glob": "^10.3.3",
     "handlebars": "^4.7.7",
     "hot-shots": "^8.5.0",

--- a/src/core/package/SfpPackageInquirer.ts
+++ b/src/core/package/SfpPackageInquirer.ts
@@ -87,7 +87,19 @@ export default class SfpPackageInquirer {
         let remoteURL: gitUrlParse.GitUrl;
 
         for (let sfpPackage of this.sfpPackages) {
-            let currentRemoteURL = gitUrlParse(sfpPackage.repository_url);
+            let currentRemoteURL: gitUrlParse.GitUrl;
+
+            try {
+                currentRemoteURL = gitUrlParse(sfpPackage.repository_url);
+            } catch (ex) {
+                if (ex instanceof Error && ex.message === 'URL parsing failed.') {
+                    throw new Error(
+                        `Invalid repository URL for package '${sfpPackage.package_name}': ${sfpPackage.repository_url}`
+                    );
+                } else {
+                    throw ex;
+                }
+            }
 
             if (remoteURL == null) {
                 remoteURL = currentRemoteURL;

--- a/tests/core/package/SfpPackageInquirer.test.ts
+++ b/tests/core/package/SfpPackageInquirer.test.ts
@@ -15,8 +15,7 @@ describe('validateArtifactsSourceRepository', () => {
             sfpPackageInquirer.validateArtifactsSourceRepository();
         });
 
-        // TODO: re-enable once https://github.com/flxbl-io/sfp/issues/137 is fixed
-        it.skip.failing('should accept a good repository SSH URL with a URL-encoded space', async () => {
+        it('should accept a good repository SSH URL with a URL-encoded space', async () => {
             const repositoryUrl = 'git@github.com:flxbl-io/sfp%20test.git';
 
             let sfpPackage: SfpPackage = new SfpPackage();

--- a/tests/core/package/SfpPackageInquirer.test.ts
+++ b/tests/core/package/SfpPackageInquirer.test.ts
@@ -1,0 +1,46 @@
+import { expect } from '@jest/globals';
+import SfpPackage from '../../../lib/core/package/SfpPackage';
+import SfpPackageInquirer from '../../../src/core/package/SfpPackageInquirer';
+
+describe('validateArtifactsSourceRepository', () => {
+    describe('Given a bad repository URL, display', () => {
+        it('should accept a good repository SSH URL', async () => {
+            const repositoryUrl = 'git@github.com:flxbl-io/sfp-test.git';
+
+            let sfpPackage: SfpPackage = new SfpPackage();
+            sfpPackage.package_name = 'testPackageName';
+            sfpPackage.repository_url = repositoryUrl;
+
+            let sfpPackageInquirer = new SfpPackageInquirer([sfpPackage]);
+            sfpPackageInquirer.validateArtifactsSourceRepository();
+        });
+
+        // TODO: re-enable once https://github.com/flxbl-io/sfp/issues/137 is fixed
+        it.skip.failing('should accept a good repository SSH URL with a URL-encoded space', async () => {
+            const repositoryUrl = 'git@github.com:flxbl-io/sfp%20test.git';
+
+            let sfpPackage: SfpPackage = new SfpPackage();
+            sfpPackage.package_name = 'testPackageName';
+            sfpPackage.repository_url = repositoryUrl;
+
+            let sfpPackageInquirer = new SfpPackageInquirer([sfpPackage]);
+            sfpPackageInquirer.validateArtifactsSourceRepository();
+        });
+
+        it('should reject a bad repository SSH URL with a helpful error message', async () => {
+            const repositoryUrl = 'git';
+
+            const t = () => {
+                let sfpPackage: SfpPackage = new SfpPackage();
+                sfpPackage.package_name = 'testPackageName';
+                sfpPackage.repository_url = repositoryUrl;
+
+                let sfpPackageInquirer = new SfpPackageInquirer([sfpPackage]);
+                sfpPackageInquirer.validateArtifactsSourceRepository();
+            };
+
+            expect(t).toThrow(Error);
+            expect(t).toThrow("Invalid repository URL for package 'testPackageName': git");
+        });
+    });
+});


### PR DESCRIPTION
This fixes #137 

If the repository URL includes an URL-encoded space (i.e., `%20`), `sfp install` will fail to parse it.  The user is presented with a rather unhelpful message:

> Error: URL parsing failed.

This PR makes 2 changes:

* URL-encoded spaces are now supported; and,
* the error message now includes the affected package and the URL in question.

> Error: Invalid repository URL for package '$PACKAGE_NAME': $REPOSITORY_URL

![Screenshot from 2024-11-08 09-10-53](https://github.com/user-attachments/assets/46faa9a3-6663-4349-b531-bdaed102ecee)

A test was added to support the problematic case.

#### Checklist
All items have to be completed before a PR is merged

- [X] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl) _The link is broken._
- [X] Updates to Decision Records considered? _Not needed, I think._
- [X] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/docs-sfp) considered?  _None needed, I think._
- [X] Tested changes?
- [X] Unit Tests new and existing passing locally?
