### PR TITLE
feat(permsets): add maxwaittime attribute to psg awaiter

### DIFF
--- a/src/core/permsets/PermissionSetGroupUpdateAwaiter.ts
+++ b/src/core/permsets/PermissionSetGroupUpdateAwaiter.ts
@@ -3,17 +3,19 @@ import SFPLogger, { Logger, LoggerLevel } from '@flxbl-io/sfp-logger';
 import QueryHelper from '../queryHelper/QueryHelper';
 import { delay } from '../utils/Delay';
 
-const psGroupQuery = `SELECT Id,MasterLabel,Status FROM PermissionSetGroup WHERE Status IN ('Updating', 'Outdated')`;
+const psGroupQuery = `SELECT Id,MasterLabel,Status FROM PermissionSetGroup WHERE Status = 'Updating'`;
 
 export default class PermissionSetGroupUpdateAwaiter {
-    constructor(private connection: Connection, private logger: Logger, private intervalBetweenRepeats = 60000) {}
+    constructor(
+        private connection: Connection,
+        private logger: Logger,
+        private intervalBetweenRepeats = 30000,
+        private maxWaitingTime = undefined
+    ) {}
 
     async waitTillAllPermissionSetGroupIsUpdated() {
-        SFPLogger.log(
-            `Checking status of permission sets group..`,
-            LoggerLevel.INFO,
-            this.logger
-        );
+        SFPLogger.log(`Checking status of permission sets group..`, LoggerLevel.INFO, this.logger);
+        let totalTimeWaited = 0;
         while (true) {
             try {
                 let records = await QueryHelper.query(psGroupQuery, this.connection, false);
@@ -29,6 +31,17 @@ export default class PermissionSetGroupUpdateAwaiter {
                         this.logger
                     );
                     await delay(this.intervalBetweenRepeats);
+                    totalTimeWaited += this.intervalBetweenRepeats;
+                    if (this.maxWaitingTime && totalTimeWaited > this.maxWaitingTime) {
+                        SFPLogger.log(
+                            `Max waiting time of ${
+                                this.maxWaitingTime / 1000
+                            } seconds exceeded. Proceeding with deployment`,
+                            LoggerLevel.WARN,
+                            this.logger
+                        );
+                        break;
+                    }
                 } else {
                     SFPLogger.log(
                         `Proceeding with deployment, as no PermissionSetGroups are being updated`,
@@ -44,3 +57,4 @@ export default class PermissionSetGroupUpdateAwaiter {
         }
     }
 }
+ 

--- a/tests/core/permsets/PermissionSetGroupUpdateAwaiter.test.ts
+++ b/tests/core/permsets/PermissionSetGroupUpdateAwaiter.test.ts
@@ -6,6 +6,32 @@ import PermissionSetGroupUpdateAwaiter from '../../../src/core/permsets/Permissi
 import { expect } from '@jest/globals';
 
 describe('Await till permissionsets groups are updated', () => {
+    const noUpdatingPsgRecords: AnyJson = {
+        records: [],
+    };
+    const someUpdatingPsgRecords: AnyJson = {
+        records: [
+            {
+                attributes: {
+                    type: 'PermissionSetGroup',
+                    url: '/services/data/v64.0/sobjects/PermissionSetGroup/0PG250000008nhNGAQ',
+                },
+                Id: '0PG250000008nhNGAQ',
+                MasterLabel: 'PSG1',
+                Status: 'Updating',
+            },
+            {
+                attributes: {
+                    type: 'PermissionSetGroup',
+                    url: '/services/data/v64.0/sobjects/PermissionSetGroup/0PG250000008nnVGAQ',
+                },
+                Id: '0PG250000008nnVGAQ',
+                MasterLabel: 'PSG2',
+                Status: 'Updating',
+            },
+        ],
+    };
+
     it('should return if all permsets groups are updated', async () => {
         const testData = new MockTestOrgData();
 
@@ -15,11 +41,8 @@ describe('Await till permissionsets groups are updated', () => {
             contents: await testData.getConfig(),
         });
 
-        let records: AnyJson = {
-            records: [],
-        };
         $$.fakeConnectionRequest = (request: AnyJson): Promise<AnyJson> => {
-            return Promise.resolve(records);
+            return Promise.resolve(noUpdatingPsgRecords);
         };
 
         const connection: Connection = await Connection.create({
@@ -32,4 +55,137 @@ describe('Await till permissionsets groups are updated', () => {
         );
         await expect(permissionSetGroupUpdateAwaiter.waitTillAllPermissionSetGroupIsUpdated()).resolves.toBeUndefined();
     });
+
+    it('should return if all permsets groups are updated after waiting for some time', async () => {
+        const testData = new MockTestOrgData();
+
+        await $$.stubConfig({ [OrgConfigProperties.TARGET_ORG]: testData.username });
+        await $$.stubAuths(testData);
+        $$.setConfigStubContents('AuthInfoConfig', {
+            contents: await testData.getConfig(),
+        });
+
+        let tryCount = 0;
+        $$.fakeConnectionRequest = (request: AnyJson): Promise<AnyJson> => {
+            if (tryCount === 0) {
+                tryCount++;
+                return Promise.resolve(someUpdatingPsgRecords);
+            }
+            return Promise.resolve(noUpdatingPsgRecords);
+        };
+
+        // need tom mock the imported delay util to return immediately
+        jest.spyOn(require('../../utils/Delay'), 'delay').mockImplementation(() => Promise.resolve());
+
+        const connection: Connection = await Connection.create({
+            authInfo: await AuthInfo.create({ username: testData.username }),
+        });
+
+        let permissionSetGroupUpdateAwaiter: PermissionSetGroupUpdateAwaiter = new PermissionSetGroupUpdateAwaiter(
+            connection,
+            null
+        );
+        await expect(permissionSetGroupUpdateAwaiter.waitTillAllPermissionSetGroupIsUpdated()).resolves.toBeUndefined();
+    });
+
+    it('should keep trying until all permsets groups are updated if there is no maximum wait time', async () => {
+        const testData = new MockTestOrgData();
+
+        await $$.stubConfig({ [OrgConfigProperties.TARGET_ORG]: testData.username });
+        await $$.stubAuths(testData);
+        $$.setConfigStubContents('AuthInfoConfig', {
+            contents: await testData.getConfig(),
+        });
+
+        let tryCount = 0;
+        $$.fakeConnectionRequest = (request: AnyJson): Promise<AnyJson> => {
+            if (tryCount < 5) {
+                // 5th try
+                tryCount++;
+                return Promise.resolve(someUpdatingPsgRecords);
+            }
+            return Promise.resolve(noUpdatingPsgRecords);
+        };
+
+        // need tom mock the imported delay util to return immediately
+        jest.spyOn(require('../utils/Delay'), 'delay').mockImplementation(() => Promise.resolve());
+
+        const connection: Connection = await Connection.create({
+            authInfo: await AuthInfo.create({ username: testData.username }),
+        });
+
+        let permissionSetGroupUpdateAwaiter: PermissionSetGroupUpdateAwaiter = new PermissionSetGroupUpdateAwaiter(
+            connection,
+            null
+        );
+        await expect(permissionSetGroupUpdateAwaiter.waitTillAllPermissionSetGroupIsUpdated()).resolves.toBeUndefined();
+        expect(tryCount).toBe(5);
+    });
+
+    it('should keep trying until until max wait time is reached', async () => {
+        const testData = new MockTestOrgData();
+
+        await $$.stubConfig({ [OrgConfigProperties.TARGET_ORG]: testData.username });
+        await $$.stubAuths(testData);
+        $$.setConfigStubContents('AuthInfoConfig', {
+            contents: await testData.getConfig(),
+        });
+
+        $$.fakeConnectionRequest = (request: AnyJson): Promise<AnyJson> => {
+            return Promise.resolve(someUpdatingPsgRecords);
+        };
+
+        // need tom mock the imported delay util to return immediately
+        jest.spyOn(require('../utils/Delay'), 'delay').mockImplementation(() => Promise.resolve());
+
+        const connection: Connection = await Connection.create({
+            authInfo: await AuthInfo.create({ username: testData.username }),
+        });
+
+        let permissionSetGroupUpdateAwaiter: PermissionSetGroupUpdateAwaiter = new PermissionSetGroupUpdateAwaiter(
+            connection,
+            null,
+            100, // try every 100ms,
+            500 // max wait time of 500ms
+        );
+        await expect(permissionSetGroupUpdateAwaiter.waitTillAllPermissionSetGroupIsUpdated()).resolves.toBeUndefined();
+    });
+
+    it('should not reach maximum time if all permsets groups udpated', async () => {
+        const testData = new MockTestOrgData();
+
+        await $$.stubConfig({ [OrgConfigProperties.TARGET_ORG]: testData.username });
+        await $$.stubAuths(testData);
+        $$.setConfigStubContents('AuthInfoConfig', {
+            contents: await testData.getConfig(),
+        });
+
+        let tryCount = 0;
+        $$.fakeConnectionRequest = (request: AnyJson): Promise<AnyJson> => {
+            if (tryCount < 3) {
+                // 3rd try in 300ms
+                tryCount++;
+                return Promise.resolve(someUpdatingPsgRecords);
+            }
+            return Promise.resolve(noUpdatingPsgRecords);
+        };
+
+        // need tom mock the imported delay util to return immediately
+        jest.spyOn(require('../utils/Delay'), 'delay').mockImplementation(() => Promise.resolve());
+
+        const connection: Connection = await Connection.create({
+            authInfo: await AuthInfo.create({ username: testData.username }),
+        });
+
+        let permissionSetGroupUpdateAwaiter: PermissionSetGroupUpdateAwaiter = new PermissionSetGroupUpdateAwaiter(
+            connection,
+            null,
+            100, // try every 100ms,
+            500 // max wait time of 500ms
+        );
+        await expect(permissionSetGroupUpdateAwaiter.waitTillAllPermissionSetGroupIsUpdated()).resolves.toBeUndefined();
+        expect(tryCount).toBe(3); // 4 tries in total, first and then waiting 3 times
+    });
 });
+
+ 


### PR DESCRIPTION
I tried to make a start at updating the PSG awaiter, which is causing us a lot of headaches. We have large PSGs and update them very frequently. For some reason every now and then some of them just get stuck at "updating" status for several hours and our development pipelines basically stop. 

I wonder what would be a better approach:
- extend `SfpPackageInstallationOptions` and update all install/deploy commands to support a new argument
- use an ENV variable

I've had some issues running these tests, though I originally wrote this in the old repository with lerna and there they ran fine. Nevertheless this is a draft only.

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/docs-sfp) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?
