### PR TITLE
feat(deployment): Use native SF polling instead of hard coded 30 seconds

### DIFF
--- a/src/core/deployers/DeploySourceToOrgImpl.ts
+++ b/src/core/deployers/DeploySourceToOrgImpl.ts
@@ -185,7 +185,6 @@ export default class DeploySourceToOrgImpl implements DeploymentExecutor {
         // Wait for polling to finish and get the DeployResult object
         const hoursInWaitTime = Number(this.deploymentOptions.waitTime) / 60;
         const result = await deploy.pollStatus({
-            frequency: Duration.seconds(30),
             timeout: Duration.hours(hoursInWaitTime),
         });
         return result;


### PR DESCRIPTION
#### Checklist
- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/docs-sfp) considered?
- [x] Tested changes?
- [x] Unit Tests new and existing passing locally?

In our experience, using the native SF polling frequency is much faster than the current hard coded 30 second polling. Especially when preparing pools

<img width="625" height="173" alt="image" src="https://github.com/user-attachments/assets/95038637-9fc0-4379-a41b-bad3c3dee3cd" />
