### PR TITLE
feat: implement dependency-aware package ordering in release process

### DIFF
--- a/src/impl/deploy/DeployImpl.ts
+++ b/src/impl/deploy/DeployImpl.ts
@@ -25,6 +25,7 @@ import convertBuildNumDotDelimToHyphen from '../../core/utils/VersionNumberConve
 import ReleaseConfigLoader from '../release/ReleaseConfigLoader';
 import { Align, getMarkdownTable } from 'markdown-table-ts';
 import FileOutputHandler from '../../outputs/FileOutputHandler';
+import TransitiveDependencyResolver from '../../core/package/dependencies/TransitiveDependencyResolver';
 
 const Table = require('cli-table');
 const retry = require('async-retry');
@@ -133,7 +134,7 @@ export default class DeployImpl {
 
             SFPLogger.log('Artifacts' + JSON.stringify(packagesToPackageInfo), LoggerLevel.TRACE, this.props.logger);
 
-            queue = this.getPackagesToDeploy(sfdxProjectConfig, packagesToPackageInfo);
+            queue = await this.getPackagesToDeploy(sfdxProjectConfig, packagesToPackageInfo);
 
 
             SFPLogger.log('queue:' + JSON.stringify(queue), LoggerLevel.TRACE, this.props.logger);
@@ -853,12 +854,12 @@ export default class DeployImpl {
     }
 
     /**
-     * Returns the packages in the project config that have an artifact
+     * Returns the packages in the project config that have an artifact, sorted by dependency order
      */
-    private getPackagesToDeploy(
+    private async getPackagesToDeploy(
         sfdxProjectConfig: any,
         packagesToPackageInfo: { [p: string]: PackageInfo }
-    ): SfpPackage[] {
+    ): Promise<SfpPackage[]> {
         let packagesToDeploy: SfpPackage[] = [];
 
         let packages = sfdxProjectConfig['packageDirectories'];
@@ -886,8 +887,51 @@ export default class DeployImpl {
             else return true;
         });
 
+        // Sort packages by dependency order using TransitiveDependencyResolver
+        packagesToDeploy = await this.sortPackagesByDependencyOrder(packagesToDeploy, sfdxProjectConfig);
+
         return packagesToDeploy;
     }
+
+    /**
+     * Sorts packages by dependency order using TransitiveDependencyResolver
+     */
+    private async sortPackagesByDependencyOrder(packages: SfpPackage[], sfdxProjectConfig: any): Promise<SfpPackage[]> {
+        try {
+            // Check if there are any dependencies in the project config
+            const pkgWithDependencies = ProjectConfig.getAllPackagesAndItsDependencies(sfdxProjectConfig);
+            if (!Array.from(pkgWithDependencies.values()).some(deps => deps.length > 0)) {
+                SFPLogger.log(`No package dependencies found, using original order`, LoggerLevel.INFO, this.props.logger);
+                return packages;
+            }
+
+            // Use TransitiveDependencyResolver to get the proper dependency order
+            const resolver = new TransitiveDependencyResolver(sfdxProjectConfig, this.props.logger);
+            const resolvedDependencies = await resolver.resolveTransitiveDependencies();
+            
+            // Extract sorted package names from the resolved dependencies map
+            const sortedNames = Array.from(resolvedDependencies.keys());
+            
+            // Create package map and reorder packages
+            const packageMap = new Map(packages.map(pkg => [pkg.packageName, pkg]));
+            const sortedPackages = [
+                ...sortedNames.map(name => packageMap.get(name)).filter(Boolean),
+                ...packages.filter(pkg => !sortedNames.includes(pkg.packageName))
+            ];
+
+            SFPLogger.log(
+                `Dependency-aware order: ${sortedPackages.map(pkg => pkg.packageName).join(' -> ')}`,
+                LoggerLevel.INFO,
+                this.props.logger
+            );
+
+            return sortedPackages;
+        } catch (error) {
+            SFPLogger.log(`Dependency sort failed, using original order: ${error.message}`, LoggerLevel.WARN, this.props.logger);
+            return packages;
+        }
+    }
+
 }
 
 export interface PackageInfo {

--- a/src/impl/release/ReleaseDefinitionSorter.ts
+++ b/src/impl/release/ReleaseDefinitionSorter.ts
@@ -1,26 +1,80 @@
-import { Logger } from '@flxbl-io/sfp-logger';
+import { Logger, LoggerLevel } from '@flxbl-io/sfp-logger';
 import SfpPackageInquirer from '../../core/package/SfpPackageInquirer';
 import ProjectConfig from '../../core/project/ProjectConfig';
 import ArtifactFetcher, { Artifact } from '../../core/artifacts/ArtifactFetcher';
 import SfpPackage from '../../core/package/SfpPackage';
 import SfpPackageBuilder from '../../core/package/SfpPackageBuilder';
 import ReleaseDefinition from './ReleaseDefinition';
+import TransitiveDependencyResolver from '../../core/package/dependencies/TransitiveDependencyResolver';
 import _ from 'lodash';
 
 export default class ReleaseDefinitionSorter {
 
-    public sortReleaseDefinitions(
+    public async sortReleaseDefinitions(
+        releaseDefinitions: ReleaseDefinition[],
+        leadingSfProjectConfig: any,
+        logger: Logger
+    ): Promise<ReleaseDefinition[]> {
+        const clonedReleaseDefintions: ReleaseDefinition[] = _.cloneDeep(releaseDefinitions);
+
+        try {
+            // Try dependency-aware sorting
+            const resolver = new TransitiveDependencyResolver(leadingSfProjectConfig, logger);
+            const resolvedDependencies = await resolver.resolveTransitiveDependencies();
+
+            // Build release dependency graph and check if dependencies exist
+            const releaseDeps = this.buildReleaseDependencyGraph(clonedReleaseDefintions, resolvedDependencies);
+            const hasDependencies = Array.from(releaseDeps.values()).some(deps => deps.size > 0);
+
+            if (hasDependencies) {
+                const sorted = this.topologicalSortReleases(releaseDeps, clonedReleaseDefintions);
+                logger.log(`Dependency-aware order: ${sorted.map(rel => rel.release).join(' -> ')}`, LoggerLevel.INFO);
+                return sorted;
+            }
+
+            logger.log(`No inter-release dependencies found, using original sorting logic`, LoggerLevel.INFO);
+        } catch (error) {
+            logger.log(`Dependency sort failed, using original logic: ${error.message}`, LoggerLevel.WARN);
+        }
+
+        // Fallback to original logic
+        return this.sortByFirstUniquePackage(clonedReleaseDefintions, leadingSfProjectConfig, logger);
+    }
+
+    private buildReleaseDependencyGraph(
+        releaseDefinitions: ReleaseDefinition[],
+        resolvedDependencies: Map<string, { package: string; versionNumber?: string }[]>
+    ): Map<string, Set<string>> {
+        const releaseDeps = new Map<string, Set<string>>();
+
+        releaseDefinitions.forEach(release => {
+            const dependencies = new Set<string>();
+
+            Object.keys(release.artifacts).forEach(pkg => {
+                (resolvedDependencies.get(pkg) || []).forEach(dep => {
+                    const dependentRelease = releaseDefinitions.find(rel =>
+                        Object.keys(rel.artifacts).includes(dep.package) && rel.release !== release.release
+                    );
+                    if (dependentRelease) dependencies.add(dependentRelease.release);
+                });
+            });
+
+            releaseDeps.set(release.release, dependencies);
+        });
+
+        return releaseDeps;
+    }
+
+    private sortByFirstUniquePackage(
         releaseDefinitions: ReleaseDefinition[],
         leadingSfProjectConfig: any,
         logger: Logger
     ): ReleaseDefinition[] {
-
-        let clonedReleaseDefintions:ReleaseDefinition[] = _.cloneDeep(releaseDefinitions);
         const allPackagesInConfig = ProjectConfig.getAllPackagesFromProjectConfig(leadingSfProjectConfig);
         const packageOccurrenceCount = new Map<string, number>();
 
         // Count occurrences of each package across all release definitions
-        clonedReleaseDefintions.forEach((releaseDefinition) => {
+        releaseDefinitions.forEach((releaseDefinition) => {
             Object.keys(releaseDefinition.artifacts).forEach((pkg) => {
                 if (allPackagesInConfig.includes(pkg)) {
                     // Only consider packages present in the project config
@@ -28,18 +82,48 @@ export default class ReleaseDefinitionSorter {
                 }
             });
         });
+
         // Annotate each release definition with the index of its first unique package
-        clonedReleaseDefintions.forEach((releasedefnition) => {
-            releasedefnition['firstUniquePackageIndex'] = allPackagesInConfig.length; // Default to length (i.e., end) if no unique package is found
+        releaseDefinitions.forEach((releaseDefinition) => {
+            releaseDefinition['firstUniquePackageIndex'] = allPackagesInConfig.length; // Default to length (i.e., end) if no unique package is found
             for (const pkg of allPackagesInConfig) {
-                if (releasedefnition.artifacts[pkg] && packageOccurrenceCount.get(pkg) === 1) {
+                if (releaseDefinition.artifacts[pkg] && packageOccurrenceCount.get(pkg) === 1) {
                     // Check if the package is unique
-                    releasedefnition['firstUniquePackageIndex'] = allPackagesInConfig.indexOf(pkg);
+                    releaseDefinition['firstUniquePackageIndex'] = allPackagesInConfig.indexOf(pkg);
                     break; // Found the first unique package, no need to continue
                 }
             }
         });
+
         // Sort based on the first unique package's index, placing those without a unique package at the end
-        return clonedReleaseDefintions.sort((a, b) => a['firstUniquePackageIndex'] - b['firstUniquePackageIndex']);
+        return releaseDefinitions.sort((a, b) => a['firstUniquePackageIndex'] - b['firstUniquePackageIndex']);
+    }
+
+    private topologicalSortReleases(
+        releaseDefinitionDeps: Map<string, Set<string>>,
+        releaseDefinitions: ReleaseDefinition[]
+    ): ReleaseDefinition[] {
+        const visited = new Set<string>();
+        const result: ReleaseDefinition[] = [];
+        const releaseMap = new Map<string, ReleaseDefinition>();
+
+        releaseDefinitions.forEach(rel => releaseMap.set(rel.release, rel));
+
+        const visit = (releaseName: string) => {
+            if (!visited.has(releaseName)) {
+                visited.add(releaseName);
+                const dependencies = releaseDefinitionDeps.get(releaseName) || new Set();
+                dependencies.forEach(dep => visit(dep));
+
+                const releaseDefinition = releaseMap.get(releaseName);
+                if (releaseDefinition) {
+                    result.push(releaseDefinition);
+                }
+            }
+        };
+
+        releaseDefinitions.forEach(rel => visit(rel.release));
+
+        return result;
     }
 }

--- a/src/impl/release/ReleaseImpl.ts
+++ b/src/impl/release/ReleaseImpl.ts
@@ -283,7 +283,7 @@ export default class ReleaseImpl {
         let sfdxProjectConfig = sfpPackageInquirer.getLatestProjectConfig();
        
         let releaseDefinitionSorter = new ReleaseDefinitionSorter();
-        return releaseDefinitionSorter.sortReleaseDefinitions(releaseDefns, sfdxProjectConfig, logger);
+        return await releaseDefinitionSorter.sortReleaseDefinitions(releaseDefns, sfdxProjectConfig, logger);
     }
 
     private async generateSfpPackageFromArtifacts(artifacts: Artifact[], logger: Logger): Promise<SfpPackage[]> {

--- a/tests/impl/release/ReleaseDefinitionSorter.test.ts
+++ b/tests/impl/release/ReleaseDefinitionSorter.test.ts
@@ -1,6 +1,7 @@
 import { ConsoleLogger } from '@flxbl-io/sfp-logger';
 import ReleaseDefinitionSorter from '../../../src/impl/release/ReleaseDefinitionSorter'; // Adjust the import path to where your function is defined
 import { expect } from '@jest/globals';
+import ReleaseDefinition from '../../../src/impl/release/ReleaseDefinition';
 
 describe('Sort Release Definitions by leading project config', () => {
     it('should sort release definitions when packages are shared', async () => {
@@ -37,7 +38,7 @@ describe('Sort Release Definitions by leading project config', () => {
 
         // Call the function to test
         const sortedReleaseDefinitions = await new ReleaseDefinitionSorter().sortReleaseDefinitions(
-            releaseDefinitions,
+            releaseDefinitions as unknown as ReleaseDefinition[],
             leadingSfProjectConfig,
             new ConsoleLogger()
         );
@@ -81,7 +82,7 @@ describe('Sort Release Definitions by leading project config', () => {
 
         // Call the function to test
         const sortedReleaseDefinitions = await new ReleaseDefinitionSorter().sortReleaseDefinitions(
-            releaseDefinitions,
+            releaseDefinitions as unknown as ReleaseDefinition[],
             leadingSfProjectConfig,
             new ConsoleLogger()
         );
@@ -113,7 +114,7 @@ describe('Sort Release Definitions by leading project config', () => {
 
       // Call the function to test
       const sortedReleaseDefinitions = await new ReleaseDefinitionSorter().sortReleaseDefinitions(
-          releaseDefinitions,
+          releaseDefinitions as unknown as ReleaseDefinition[],
           leadingSfProjectConfig,
           new ConsoleLogger()
       );
@@ -157,7 +158,7 @@ describe('Sort Release Definitions by leading project config', () => {
 
       // Call the function to test
       const sortedReleaseDefinitions = await new ReleaseDefinitionSorter().sortReleaseDefinitions(
-          releaseDefinitions,
+          releaseDefinitions as unknown as ReleaseDefinition[],
           leadingSfProjectConfig,
           new ConsoleLogger()
       );
@@ -165,5 +166,60 @@ describe('Sort Release Definitions by leading project config', () => {
       const sortedReleaseOrder = sortedReleaseDefinitions.map((def) => def.release);
       const expectedReleaseOrder = ['Release2', 'Release1', 'Release3'];
       expect(sortedReleaseOrder).toEqual(expectedReleaseOrder);
+  });
+
+  it('should sort release definitions based on package dependencies', async () => {
+    // Mock input data with dependencies
+    const releaseDefinitions = [
+        {
+            release: 'Release3',
+            artifacts: { PackageC: '1.0.0' }, // PackageC depends on PackageB
+            skipIfAlreadyInstalled: false,
+            skipArtifactUpdate: false,
+        },
+        {
+            release: 'Release1',
+            artifacts: { PackageA: '1.0.0' }, // PackageA has no dependencies
+            skipIfAlreadyInstalled: false,
+            skipArtifactUpdate: false,
+        },
+        {
+            release: 'Release2',
+            artifacts: { PackageB: '1.0.0' }, // PackageB depends on PackageA
+            skipIfAlreadyInstalled: false,
+            skipArtifactUpdate: false,
+        },
+    ];
+    const leadingSfProjectConfig = {
+        packageDirectories: [
+            { 
+                package: 'PackageA', 
+                versionNumber: '1.0.0'
+                // No dependencies
+            },
+            { 
+                package: 'PackageB', 
+                versionNumber: '1.0.0',
+                dependencies: [{ package: 'PackageA', versionNumber: '1.0.0' }]
+            },
+            { 
+                package: 'PackageC', 
+                versionNumber: '1.0.0',
+                dependencies: [{ package: 'PackageB', versionNumber: '1.0.0' }]
+            },
+        ],
+    };
+
+    // Call the function to test
+    const sortedReleaseDefinitions = await new ReleaseDefinitionSorter().sortReleaseDefinitions(
+        releaseDefinitions as unknown as ReleaseDefinition[],
+        leadingSfProjectConfig,
+        new ConsoleLogger()
+    );
+
+    const sortedReleaseOrder = sortedReleaseDefinitions.map((def) => def.release);
+    // Expected order: Release1 (PackageA) -> Release2 (PackageB) -> Release3 (PackageC)
+    const expectedReleaseOrder = ['Release1', 'Release2', 'Release3'];
+    expect(sortedReleaseOrder).toEqual(expectedReleaseOrder);
   });
 });


### PR DESCRIPTION
- Enhance DeployImpl to sort packages by dependency order using topological sort
- Improve ReleaseDefinitionSorter to consider package dependencies between releases
- Add dependency-aware sorting with fallback to original logic for robustness
- Include comprehensive logging for debugging deployment order
- Add test case to verify dependency-aware release definition sorting

Fixes #187




#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/docs-sfp) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?
