### PR TITLE
Feature/limit org create batch size

### DIFF
--- a/src/core/scratchorg/pool/PoolConfig.ts
+++ b/src/core/scratchorg/pool/PoolConfig.ts
@@ -6,6 +6,7 @@ export interface PoolConfig {
     waitTime?: number;
     expiry?: number;
     batchSize?: number;
+    allocateSingleBatch?: boolean;
     configFilePath: string;
     releaseConfigFile?:string;
     succeedOnDeploymentErrors?: boolean;

--- a/src/core/scratchorg/pool/PoolCreateImpl.ts
+++ b/src/core/scratchorg/pool/PoolCreateImpl.ts
@@ -160,10 +160,7 @@ export default class PoolCreateImpl extends PoolBaseImpl {
     ) {
         pool.current_allocation = countOfActiveScratchOrgs;
         pool.to_allocate = 0;
-        pool.to_satisfy_max = Math.min(
-            pool.maxAllocation - pool.current_allocation > 0 ? pool.maxAllocation - pool.current_allocation : 0,
-            pool.batchSize
-        );
+        pool.to_satisfy_max = pool.maxAllocation - pool.current_allocation > 0 ? pool.maxAllocation - pool.current_allocation : 0;
 
         if (pool.snapshotPool && pool.to_satisfy_max > 0){
             pool.to_allocate = pool.to_satisfy_max;
@@ -171,6 +168,10 @@ export default class PoolCreateImpl extends PoolBaseImpl {
             pool.to_allocate = pool.to_satisfy_max;
         } else if (pool.to_satisfy_max > 0 && pool.to_satisfy_max > remainingScratchOrgs) {
             pool.to_allocate = remainingScratchOrgs;
+        }
+
+        if (pool.allocateSingleBatch) {
+            pool.to_allocate = pool.to_allocate > pool.batchSize ? pool.batchSize : pool.to_allocate;
         }
 
         SFPLogger.log(

--- a/src/core/scratchorg/pool/PoolCreateImpl.ts
+++ b/src/core/scratchorg/pool/PoolCreateImpl.ts
@@ -160,8 +160,10 @@ export default class PoolCreateImpl extends PoolBaseImpl {
     ) {
         pool.current_allocation = countOfActiveScratchOrgs;
         pool.to_allocate = 0;
-        pool.to_satisfy_max =
-            pool.maxAllocation - pool.current_allocation > 0 ? pool.maxAllocation - pool.current_allocation : 0;
+        pool.to_satisfy_max = Math.min(
+            pool.maxAllocation - pool.current_allocation > 0 ? pool.maxAllocation - pool.current_allocation : 0,
+            pool.batchSize
+        );
 
         if (pool.snapshotPool && pool.to_satisfy_max > 0){
             pool.to_allocate = pool.to_satisfy_max;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "skipLibCheck": true,
         "esModuleInterop": true,
         "module": "NodeNext",
+        "moduleResolution": "NodeNext",
         "target": "ES2020",
         "lib": ["ES2020"],
         "resolveJsonModule": true


### PR DESCRIPTION
We've found for long running pool create jobs, where our custom script takes hours to complete, we have a need to provision in single batches.

e.g. if it takes 4 hours to provision an org, and we want a pool of 40 orgs, running `sfp prepare` will first allocate all orgs up to 40, then slowly work through them, with any subsequent runs of `sfp prepare` doing nothing as the other process has taken responsibility for all prepares in the pool, greatly limiting ability to provision orgs proactively.

In the case of 0 currently allocated, with a batch size of 5, the run would take 32 hours to fill, whereas if we limit each prepare call to handle a single batch, running another processes every ~10 minutes, then we can fill all orgs in ~5h 20m instead.

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [X] Updates to Decision Records considered?
- [ ] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/docs-sfp) considered? 
 Will be required if this change is approved
- [X] Tested changes?
- [ ] Unit Tests new and existing passing locally?
