### PR TITLE
fix(pool): implement retry logic for fetching org details

### DIFF
--- a/src/core/scratchorg/pool/PoolCreateImpl.ts
+++ b/src/core/scratchorg/pool/PoolCreateImpl.ts
@@ -21,6 +21,7 @@ import { COLOR_SUCCESS } from '@flxbl-io/sfp-logger';
 import { COLOR_ERROR } from '@flxbl-io/sfp-logger';
 import getFormattedTime from '../../utils/GetFormattedTime';
 import path from 'path';
+const retry = require('async-retry');
 
 export default class PoolCreateImpl extends PoolBaseImpl {
     private limiter;
@@ -240,13 +241,23 @@ export default class PoolCreateImpl extends PoolBaseImpl {
             let index = scratchOrgs.length;
             while (index--) {
                 try {
-                    const orgDetails = await new OrgDetailsFetcher(scratchOrgs[index].username).getOrgDetails();
+                    const orgDetails = await retry(
+                        async (bail) => {
+                            return await new OrgDetailsFetcher(scratchOrgs[index].username).getOrgDetails();
+                        },
+                        { retries: 3, minTimeout: 2000 }
+                    );
+
                     if (orgDetails.status === 'Deleted') {
                         throw new Error(
-                            `Throwing away scratch org ${this.pool.scratchOrgs[index].alias} as it has a status of deleted`
+                            `Throwing away scratch org ${scratchOrgs[index].alias} as it has a status of deleted`
                         );
                     }
                 } catch (error) {
+                    SFPLogger.log(
+                        `Unable to check status of scratch org ${scratchOrgs[index].username} due to ${error.message}`,
+                        LoggerLevel.WARN
+                    );
                     scratchOrgs.splice(index, 1);
                 }
             }


### PR DESCRIPTION
Here is the breakdown of the problem:

- Crash on Error Handling: In the `generateScratchOrgs` method, there is a check for `orgDetails.status === 'Deleted'`. If this condition is met, the code attempts to throw an error using `this.pool.scratchOrgs[index].alias`. However, `this.pool.scratchOrgs` is undefined at this stage (it is assigned only after `generateScratchOrgs` returns). This causes a TypeError, which is caught by the catch block.
- Silent Removal: The catch block executes `scratchOrgs.splice(index, 1)`, removing the scratch org from the list. This happens silently because there was no logging in the catch block.
- Transient Failures: The `OrgDetailsFetcher` might be failing intermittently (e.g., due to file locking on Windows or race conditions when reading auth files immediately after creation). If it fails, the catch block is triggered, and the org is removed.


I have applied the following fixes:

- Fixed the Crash: Changed `this.pool.scratchOrgs[index].alias` to `scratchOrgs[index].alias` to correctly reference the local variable.
- Added Retry Logic: Wrapped the `OrgDetailsFetcher.getOrgDetails()` call with `async-retry` (3 retries) to handle transient errors robustly.
- Added Logging: Added a warning log in the catch block so that if an org is removed, the reason (error message) is printed to the console.

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [x] Updates to Decision Records considered?
- [x] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/docs-sfp) considered?
- [ ] Tested changes?
- [x] Unit Tests new and existing passing locally?
